### PR TITLE
Corrects responsive design on demo, where content broke out

### DIFF
--- a/css/website.css
+++ b/css/website.css
@@ -2796,9 +2796,23 @@ span.editlink {
 body.demo div#main > div.floatleft {
 	width: 530px;
 }
+
 body.demo div#main > div.floatright {
 	width: 300px;
 }
+
+@media only screen and (max-width: 600px), only screen and (max-device-width: 600px) {
+	body.demo div#main > div.floatleft {
+		width: auto;
+	}
+	
+	body.demo div#main > div.floatright {
+		float: none;
+		margin: 0 auto;
+		width: 300px;
+	}
+}
+
 body.demo div#main > div.floatright img {
 	width: 270px;
 	border: 1px solid #eee;


### PR DESCRIPTION
At the moment this looks broken: 
![file](https://user-images.githubusercontent.com/1311778/28211223-d3a4ddee-689b-11e7-8254-04a840bce865.png)

PR fixes this behaviour. 